### PR TITLE
[autodoc_service] 테스트 현행화 + Word 빌더 테스트 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(curl:*)",
       "mcp__wonderwhy-er-desktop-commander__start_process",
       "mcp__wonderwhy-er-desktop-commander__read_file",
-      "mcp__wonderwhy-er-desktop-commander__interact_with_process"
+      "mcp__wonderwhy-er-desktop-commander__interact_with_process",
+      "Bash(cat:*)"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ celerybeat.pid
 
 # Python environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,14 @@ Document → ensure_malgun_gothic_document() → Final Document
 
 ### AutoDoc Service-Specific Development Guidelines
 
+#### 로깅 및 테스트 표준 (Logging and Testing Standards)
+- **로깅 의무**: 모든 API 엔드포인트와 서비스 모듈에서 로그 기록 필수
+- **로그 위치**: `autodoc_service/logs/YYYYMMDD_autodoc.log` (일별 파일)
+- **로그 형식**: `"%(asctime)s | %(levelname)-8s | %(name)s | %(funcName)s:%(lineno)d | %(message)s"`
+- **로깅 패턴**: 요청 수신 → 처리 과정 → 성공/실패 결과 (처리 시간, 파일 크기 포함)
+- **테스트 완성도**: 기능 변경 시 테스트 코드 함께 작성하여 안정성 확보
+- **디버깅 지원**: 상세한 로그를 통한 문제 상황 추적 및 해결 지원
+
 #### Offline Environment Support
 **Office-less Design**: No Microsoft Office dependency, uses python-docx and openpyxl
 ```bash
@@ -537,6 +545,31 @@ cd autodoc_service && pytest --cov=app --cov-report=html app/tests/
 4. **Quality Gates**: All projects require passing tests before merge
 5. **Korean Documentation**: Technical documentation includes Korean user-facing content
 
+## Pseudo MSA 서비스 개발 원칙 (Pseudo MSA Development Principles)
+
+### 핵심 개발 원칙
+- **로깅 의무화**: 모든 백엔드 서비스는 업무 수행 시마다 로그 기록 필수
+- **테스트 의무화**: 기능 추가/변경 시 테스트 코드 생성 무조건 수반
+- **안정성 우선**: 로깅과 테스트를 통한 유지보수성과 디버깅 용이성 확보
+
+### 로깅 가이드라인
+- **기본 요구사항**: 모든 API 엔드포인트에서 요청 수신, 처리 과정, 결과 로그
+- **오류 처리**: 예외 발생 시 상세한 스택 트레이스와 컨텍스트 정보 로그
+- **성능 메트릭스**: 처리 시간, 리소스 사용량, 데이터 크기 등 기록
+- **상황별 최적화**: 서비스 특성에 맞는 로그 형식, 로테이션, 보관 정책 적용
+
+### 테스트 가이드라인
+- **동시 개발**: 기능 구현과 테스트 코드는 동시에 작성
+- **포괄적 커버리지**: Unit, Integration, E2E 테스트 모두 포함
+- **로깅 테스트**: 로그 생성 및 내용 검증 테스트 포함
+- **품질 게이트**: 테스트 통과 없이는 기능 완성 인정 안함
+
+### 구현 가이드라인
+- **새 서비스 생성 시**: 로깅 시스템 구성을 첫 번째 작업으로 수행
+- **API 엔드포인트**: 요청 수신/처리 성공/실패 로그 필수
+- **예외 처리**: `logger.exception()` 사용하여 스택 트레이스 포함
+- **성능 추적**: 처리 시간 측정 및 로그 기록으로 성능 모니터링
+
 ## Performance and Quality Standards
 
 - **Webservice API**: <200ms response time, <1s WebSocket connection
@@ -544,6 +577,7 @@ cd autodoc_service && pytest --cov=app --cov-report=html app/tests/
 - **AutoDoc Service**: <1s HTML parsing, <3s Word generation, <2s Excel generation
 - **Test Coverage**: Webservice ≥80% unit + ≥70% integration, CLI ≥85% overall, AutoDoc Service ≥85% overall
 - **Build Time**: Complete monorepo build <10 minutes
+- **Logging Coverage**: 모든 API 엔드포인트와 서비스 모듈에서 로그 기록 100%
 
 ## Critical Configuration Files
 

--- a/autodoc_service/app/logging_config.py
+++ b/autodoc_service/app/logging_config.py
@@ -1,0 +1,110 @@
+"""
+AutoDoc Service 로깅 설정
+
+AutoDoc Service에 특화된 로깅 시스템 구성
+- 일별 로그 파일 생성
+- 적절한 로그 레벨 설정
+- 서비스 특성에 맞는 로그 형식
+"""
+import logging
+import sys
+import os
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+import datetime
+
+
+class AutoDocRotatingFileHandler(TimedRotatingFileHandler):
+    """
+    AutoDoc Service용 커스텀 로그 핸들러
+    날짜별 로그 파일 생성: YYYYMMDD_autodoc.log
+    """
+    def __init__(self, when='midnight', backupCount=7, encoding=None, delay=False, utc=False, atTime=None):
+        # AutoDoc Service 로그 디렉토리 설정
+        self.log_dir = Path(__file__).resolve().parents[1] / "logs"
+        self.log_dir.mkdir(exist_ok=True)
+        
+        # 초기 파일명 구성
+        current_date = datetime.date.today().strftime('%Y%m%d')
+        filename = self.log_dir / f"{current_date}_autodoc.log"
+        
+        super().__init__(str(filename), when, 1, backupCount, encoding, delay, utc, atTime)
+
+    def doRollover(self):
+        """
+        로그 파일 롤오버 시 새로운 날짜 기반 파일명 생성
+        """
+        if self.stream:
+            self.stream.close()
+        
+        # 새로운 날짜 기반 파일명 생성
+        current_date = datetime.date.today().strftime('%Y%m%d')
+        new_filename = str(self.log_dir / f"{current_date}_autodoc.log")
+        
+        # 기존 파일이 있으면 제거 (같은 날짜 파일 덮어쓰기)
+        if os.path.exists(new_filename):
+            os.remove(new_filename)
+        
+        self.baseFilename = new_filename
+        self.stream = self._open()
+        
+        # 백업 파일 정리
+        if self.backupCount > 0:
+            for file_to_delete in self.getFilesToDelete():
+                os.remove(file_to_delete)
+
+
+def setup_autodoc_logging():
+    """
+    AutoDoc Service 로깅 설정 초기화
+    
+    - 일별 로그 파일 생성
+    - 콘솔과 파일 동시 출력
+    - AutoDoc Service에 최적화된 로그 형식
+    """
+    # 로그 디렉토리 생성
+    log_dir = Path(__file__).resolve().parents[1] / "logs"
+    log_dir.mkdir(exist_ok=True)
+    
+    # 로그 형식 설정
+    log_format = "%(asctime)s | %(levelname)-8s | %(name)s | %(funcName)s:%(lineno)d | %(message)s"
+    formatter = logging.Formatter(log_format)
+    
+    # 파일 핸들러 설정 (일별 로테이션, 7일 백업)
+    file_handler = AutoDocRotatingFileHandler(backupCount=7)
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.INFO)
+    
+    # 콘솔 핸들러 설정
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    console_handler.setLevel(logging.INFO)
+    
+    # 루트 로거 설정
+    root_logger = logging.getLogger()
+    
+    # 기존 핸들러 제거 (중복 방지)
+    if root_logger.handlers:
+        root_logger.handlers.clear()
+    
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+    
+    # AutoDoc Service 로거 초기화 메시지
+    logger = logging.getLogger(__name__)
+    logger.info("AutoDoc Service 로깅 시스템 초기화 완료")
+    logger.info(f"로그 파일 위치: {log_dir}")
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    AutoDoc Service용 로거 생성 헬퍼 함수
+    
+    Args:
+        name: 로거 이름 (보통 __name__ 사용)
+    
+    Returns:
+        설정된 로거 인스턴스
+    """
+    return logging.getLogger(name)

--- a/autodoc_service/app/main.py
+++ b/autodoc_service/app/main.py
@@ -5,12 +5,16 @@ Office-less 환경에서 동작하는 문서 자동화 서비스
 템플릿 기반 Word/Excel 문서 생성 API
 """
 import json
+import time
 from pathlib import Path
 from typing import List, Union, Dict, Any
+from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi import FastAPI, HTTPException, UploadFile, File, Request
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
+
+from .logging_config import setup_autodoc_logging, get_logger
 
 from .models import (
     ChangeRequest, 
@@ -29,11 +33,26 @@ from .services.paths import (
     verify_template_exists
 )
 
+# 로깅 시스템 초기화
+setup_autodoc_logging()
+logger = get_logger(__name__)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """AutoDoc Service 라이프사이클 매니저"""
+    # 시작 시 실행
+    logger.info("🚀 AutoDoc Service 시작")
+    logger.info("📄 문서 자동화 서비스가 활성화되었습니다")
+    yield
+    # 종료 시 실행
+    logger.info("🛑 AutoDoc Service 종료")
+
 # FastAPI 앱 초기화
 app = FastAPI(
     title="AutoDoc Service",
     description="Office-less 문서 자동화 서비스",
-    version="1.0.0"
+    version="1.0.0",
+    lifespan=lifespan
 )
 
 # CORS 설정 (개발 환경용)
@@ -47,14 +66,22 @@ app.add_middleware(
 
 
 @app.get("/", response_model=Dict[str, str])
-async def root():
+async def root(request: Request):
     """루트 엔드포인트"""
-    return {"message": "AutoDoc Service API", "version": "1.0.0"}
+    client_ip = request.client.host if request.client else "unknown"
+    logger.info(f"루트 엔드포인트 요청: client_ip={client_ip}")
+    
+    response = {"message": "AutoDoc Service API", "version": "1.0.0"}
+    logger.info("루트 엔드포인트 응답 성공")
+    return response
 
 
 @app.get("/health", response_model=HealthResponse)
-async def health_check():
+async def health_check(request: Request):
     """헬스 체크 엔드포인트"""
+    client_ip = request.client.host if request.client else "unknown"
+    logger.info(f"헬스 체크 요청: client_ip={client_ip}")
+    
     try:
         # 템플릿 파일 존재 여부 확인
         templates_available = True
@@ -65,6 +92,7 @@ async def health_check():
                 verify_template_exists(template)
             except FileNotFoundError:
                 templates_available = False
+                logger.warning(f"템플릿 파일 누락: {template}")
                 break
         
         # 문서 디렉터리 쓰기 권한 확인
@@ -72,25 +100,34 @@ async def health_check():
         
         status = "ok" if templates_available and documents_writable else "warning"
         
+        logger.info(f"헬스 체크 완료: status={status}, templates_available={templates_available}, documents_writable={documents_writable}")
+        
         return HealthResponse(
             status=status,
             templates_available=templates_available,
             documents_dir_writable=documents_writable
         )
     except Exception as e:
+        logger.exception(f"헬스 체크 실패: {str(e)}")
         raise HTTPException(status_code=500, detail=f"헬스 체크 실패: {str(e)}")
 
 
 @app.post("/parse-html", response_model=ParseHtmlResponse)
-async def parse_html_endpoint(file: UploadFile = File(...)):
+async def parse_html_endpoint(request: Request, file: UploadFile = File(...)):
     """HTML 파일 파싱 엔드포인트
     
     업로드된 HTML 파일을 파싱하여 JSON 형태로 반환
     """
+    client_ip = request.client.host if request.client else "unknown"
+    start_time = time.time()
+    
+    logger.info(f"HTML 파싱 요청: client_ip={client_ip}, filename={file.filename}, content_type={file.content_type}")
+    
     try:
         # 파일 타입 검증
         if not file.content_type or 'html' not in file.content_type.lower():
             if not file.filename or not file.filename.lower().endswith('.html'):
+                logger.warning(f"잘못된 파일 타입: filename={file.filename}, content_type={file.content_type}")
                 raise HTTPException(
                     status_code=400, 
                     detail="HTML 파일만 업로드 가능합니다"
@@ -98,22 +135,33 @@ async def parse_html_endpoint(file: UploadFile = File(...)):
         
         # 파일 내용 읽기
         content = await file.read()
+        file_size = len(content)
         html_content = content.decode('utf-8')
+        
+        logger.info(f"HTML 파일 읽기 완료: filename={file.filename}, size={file_size} bytes")
         
         # HTML 파싱
         parsed_data = parse_itsupp_html(html_content)
+        field_count = len(parsed_data) if parsed_data else 0
+        
+        processing_time = time.time() - start_time
+        logger.info(f"HTML 파싱 성공: filename={file.filename}, fields_parsed={field_count}, processing_time={processing_time:.3f}s")
         
         return ParseHtmlResponse(
             success=True,
             data=parsed_data
         )
         
-    except UnicodeDecodeError:
+    except UnicodeDecodeError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"파일 인코딩 오류: filename={file.filename}, processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(
             status_code=400,
             detail="파일 인코딩 오류: UTF-8로 인코딩된 HTML 파일이 필요합니다"
         )
     except Exception as e:
+        processing_time = time.time() - start_time
+        logger.exception(f"HTML 파싱 실패: filename={file.filename}, processing_time={processing_time:.3f}s, error={str(e)}")
         return ParseHtmlResponse(
             success=False,
             error=f"HTML 파싱 실패: {str(e)}"
@@ -121,22 +169,34 @@ async def parse_html_endpoint(file: UploadFile = File(...)):
 
 
 @app.post("/create-cm-word-enhanced", response_model=CreateDocumentResponse)
-async def create_change_management_word_enhanced(request: dict):
+async def create_change_management_word_enhanced(http_request: Request, request: dict):
     """
     향상된 변경관리 Word 문서 생성 엔드포인트
     
     Raw 파싱 데이터를 받아서 누락 필드를 자동으로 보완하여 Word 문서를 생성합니다.
     """
+    client_ip = http_request.client.host if http_request.client else "unknown"
+    start_time = time.time()
+    
+    # 요청에서 raw_data와 ChangeRequest 데이터 분리
+    raw_data = request.get("raw_data", {})
+    change_request_data = request.get("change_request", {})
+    
+    logger.info(f"Word 문서 생성 요청: client_ip={client_ip}, change_id={change_request_data.get('change_id', 'N/A')}, system={change_request_data.get('system', 'N/A')}")
+    
     try:
-        # 요청에서 raw_data와 ChangeRequest 데이터 분리
-        raw_data = request.get("raw_data", {})
-        change_request_data = request.get("change_request", {})
-        
         # ChangeRequest 객체 생성
         data = ChangeRequest(**change_request_data)
         
+        logger.info(f"ChangeRequest 객체 생성 완료: change_id={data.change_id}, title={data.title}")
+        
         # raw_data를 함께 전달하여 라벨-기반 Word 문서 생성
         output_path = build_change_request_doc_label_based(data, raw_data=raw_data)
+        
+        processing_time = time.time() - start_time
+        file_size = output_path.stat().st_size if output_path.exists() else 0
+        
+        logger.info(f"Word 문서 생성 성공: filename={output_path.name}, size={file_size} bytes, processing_time={processing_time:.3f}s")
         
         return CreateDocumentResponse(
             ok=True,
@@ -144,10 +204,16 @@ async def create_change_management_word_enhanced(request: dict):
         )
         
     except ValueError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Word 문서 생성 검증 오류: processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Word 문서 생성 파일 오류: processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
+        processing_time = time.time() - start_time
+        logger.exception(f"Word 문서 생성 실패: processing_time={processing_time:.3f}s, error={str(e)}")
         return CreateDocumentResponse(
             ok=False,
             error=f"향상된 Word 문서 생성 실패: {str(e)}"
@@ -155,11 +221,21 @@ async def create_change_management_word_enhanced(request: dict):
 
 
 @app.post("/create-test-excel", response_model=CreateDocumentResponse)
-async def create_test_scenario_excel(data: ChangeRequest):
+async def create_test_scenario_excel(request: Request, data: ChangeRequest):
     """테스트 시나리오 Excel 파일 생성 엔드포인트"""
+    client_ip = request.client.host if request.client else "unknown"
+    start_time = time.time()
+    
+    logger.info(f"Excel 테스트 시나리오 생성 요청: client_ip={client_ip}, change_id={data.change_id}, system={data.system}")
+    
     try:
         # Excel 파일 생성
         output_path = build_test_scenario_xlsx(data)
+        
+        processing_time = time.time() - start_time
+        file_size = output_path.stat().st_size if output_path.exists() else 0
+        
+        logger.info(f"Excel 테스트 시나리오 생성 성공: filename={output_path.name}, size={file_size} bytes, processing_time={processing_time:.3f}s")
         
         return CreateDocumentResponse(
             ok=True,
@@ -167,10 +243,16 @@ async def create_test_scenario_excel(data: ChangeRequest):
         )
         
     except ValueError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Excel 테스트 시나리오 검증 오류: processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Excel 테스트 시나리오 파일 오류: processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
+        processing_time = time.time() - start_time
+        logger.exception(f"Excel 테스트 시나리오 생성 실패: processing_time={processing_time:.3f}s, error={str(e)}")
         return CreateDocumentResponse(
             ok=False,
             error=f"Excel 테스트 시나리오 생성 실패: {str(e)}"
@@ -178,14 +260,26 @@ async def create_test_scenario_excel(data: ChangeRequest):
 
 
 @app.post("/create-cm-list", response_model=CreateDocumentResponse)
-async def create_change_management_list(data: List[Union[ChangeRequest, Dict[str, Any]]]):
+async def create_change_management_list(request: Request, data: List[Union[ChangeRequest, Dict[str, Any]]]):
     """변경관리 문서 목록 Excel 파일 생성 엔드포인트"""
+    client_ip = request.client.host if request.client else "unknown"
+    start_time = time.time()
+    
+    data_count = len(data) if data else 0
+    logger.info(f"Excel 변경관리 목록 생성 요청: client_ip={client_ip}, data_count={data_count}")
+    
     try:
         if not data:
+            logger.warning("Excel 변경관리 목록 생성 실패: 데이터가 비어있음")
             raise HTTPException(status_code=400, detail="데이터가 비어있습니다")
         
         # Excel 목록 파일 생성
         output_path = build_change_list_xlsx(data)
+        
+        processing_time = time.time() - start_time
+        file_size = output_path.stat().st_size if output_path.exists() else 0
+        
+        logger.info(f"Excel 변경관리 목록 생성 성공: filename={output_path.name}, data_count={data_count}, size={file_size} bytes, processing_time={processing_time:.3f}s")
         
         return CreateDocumentResponse(
             ok=True,
@@ -193,10 +287,16 @@ async def create_change_management_list(data: List[Union[ChangeRequest, Dict[str
         )
         
     except ValueError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Excel 변경관리 목록 검증 오류: data_count={data_count}, processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError as e:
+        processing_time = time.time() - start_time
+        logger.error(f"Excel 변경관리 목록 파일 오류: data_count={data_count}, processing_time={processing_time:.3f}s, error={str(e)}")
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
+        processing_time = time.time() - start_time
+        logger.exception(f"Excel 변경관리 목록 생성 실패: data_count={data_count}, processing_time={processing_time:.3f}s, error={str(e)}")
         return CreateDocumentResponse(
             ok=False,
             error=f"Excel 목록 생성 실패: {str(e)}"
@@ -204,11 +304,15 @@ async def create_change_management_list(data: List[Union[ChangeRequest, Dict[str
 
 
 @app.get("/download/{filename}")
-async def download_file(filename: str):
+async def download_file(request: Request, filename: str):
     """파일 다운로드 엔드포인트
     
     documents/ 디렉터리의 파일을 스트리밍으로 제공
     """
+    client_ip = request.client.host if request.client else "unknown"
+    
+    logger.info(f"파일 다운로드 요청: client_ip={client_ip}, filename={filename}")
+    
     try:
         # 파일 경로 생성
         documents_dir = get_documents_dir()
@@ -216,13 +320,18 @@ async def download_file(filename: str):
         
         # 파일 존재 여부 확인
         if not file_path.exists():
+            logger.warning(f"파일 다운로드 실패: 파일 없음 - filename={filename}")
             raise HTTPException(status_code=404, detail="파일을 찾을 수 없습니다")
         
         # 파일이 documents 디렉터리 내부에 있는지 확인 (보안)
         try:
             file_path.resolve().relative_to(documents_dir.resolve())
         except ValueError:
+            logger.error(f"파일 다운로드 보안 위반: path_traversal 시도 - filename={filename}, client_ip={client_ip}")
             raise HTTPException(status_code=403, detail="접근 권한이 없습니다")
+        
+        # 파일 정보 수집
+        file_size = file_path.stat().st_size
         
         # MIME 타입 결정
         content_type = "application/octet-stream"
@@ -230,6 +339,8 @@ async def download_file(filename: str):
             content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         elif filename.lower().endswith('.xlsx'):
             content_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        
+        logger.info(f"파일 다운로드 시작: filename={filename}, size={file_size} bytes, content_type={content_type}")
         
         return FileResponse(
             path=str(file_path),
@@ -240,12 +351,16 @@ async def download_file(filename: str):
     except HTTPException:
         raise
     except Exception as e:
+        logger.exception(f"파일 다운로드 예외 발생: filename={filename}, error={str(e)}")
         raise HTTPException(status_code=500, detail=f"파일 다운로드 실패: {str(e)}")
 
 
 @app.get("/templates")
-async def list_templates():
+async def list_templates(request: Request):
     """사용 가능한 템플릿 목록 반환"""
+    client_ip = request.client.host if request.client else "unknown"
+    logger.info(f"템플릿 목록 조회 요청: client_ip={client_ip}")
+    
     try:
         templates_dir = get_templates_dir()
         templates = []
@@ -264,15 +379,22 @@ async def list_templates():
                 "exists": template_file.exists()
             })
         
+        template_count = len(templates)
+        logger.info(f"템플릿 목록 조회 성공: template_count={template_count}")
+        
         return {"templates": templates}
         
     except Exception as e:
+        logger.exception(f"템플릿 목록 조회 실패: error={str(e)}")
         raise HTTPException(status_code=500, detail=f"템플릿 목록 조회 실패: {str(e)}")
 
 
 @app.get("/documents")
-async def list_documents():
+async def list_documents(request: Request):
     """생성된 문서 목록 반환"""
+    client_ip = request.client.host if request.client else "unknown"
+    logger.info(f"문서 목록 조회 요청: client_ip={client_ip}")
+    
     try:
         documents_dir = get_documents_dir()
         documents = []
@@ -288,9 +410,15 @@ async def list_documents():
         # 수정일 기준 역순 정렬
         documents.sort(key=lambda x: x['modified'], reverse=True)
         
+        document_count = len(documents)
+        total_size = sum(doc['size'] for doc in documents)
+        
+        logger.info(f"문서 목록 조회 성공: document_count={document_count}, total_size={total_size} bytes")
+        
         return {"documents": documents}
         
     except Exception as e:
+        logger.exception(f"문서 목록 조회 실패: error={str(e)}")
         raise HTTPException(status_code=500, detail=f"문서 목록 조회 실패: {str(e)}")
 
 

--- a/autodoc_service/app/tests/test_builder_word_label.py
+++ b/autodoc_service/app/tests/test_builder_word_label.py
@@ -1,0 +1,101 @@
+"""
+Word 라벨 기반 빌더 테스트
+
+라벨 기반 매핑으로 생성된 문서에 핵심 값들이 포함되는지 검증합니다.
+"""
+from pathlib import Path
+import json
+import tempfile
+
+from docx import Document
+
+from ..models import ChangeRequest
+from ..services.label_based_word_builder import build_change_request_doc_label_based
+
+
+def _collect_all_texts(doc: Document) -> list[str]:
+    texts: list[str] = []
+    # 본문 단락
+    for p in doc.paragraphs:
+        if p.text:
+            texts.append(p.text)
+    # 테이블 셀
+    for t in doc.tables:
+        for r in t.rows:
+            for c in r.cells:
+                if c.text:
+                    texts.append(c.text)
+    # 헤더/푸터
+    for section in doc.sections:
+        if section.header:
+            for p in section.header.paragraphs:
+                if p.text:
+                    texts.append(p.text)
+        if section.footer:
+            for p in section.footer.paragraphs:
+                if p.text:
+                    texts.append(p.text)
+    return texts
+
+
+class TestWordLabelBuilder:
+    def test_build_word_doc_and_mapping_contains_core_values(self):
+        # 1) 픽스처 로드
+        fixtures_dir = Path(__file__).parent / "fixtures"
+        json_file = fixtures_dir / "itsupp_sample.json"
+        with open(json_file, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+
+        # ChangeRequest(필수 최소값)
+        change_id = raw.get("변경관리번호") or "LIMS_20250728_1"
+        title = raw.get("제목") or "테스트 제목"
+        system = raw.get("시스템") or "LIMS-001"
+        requester = raw.get("요청자") or "홍길동"
+
+        change_req = ChangeRequest(
+            change_id=change_id,
+            system=system,
+            title=title,
+            requester=requester,
+            writer_short=raw.get("처리자_약칭", None),
+        )
+
+        # 2) 문서 생성
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir)
+            output_path = build_change_request_doc_label_based(change_req, out_dir=out_dir, raw_data=raw)
+
+            # 3) 파일 생성 확인
+            assert output_path.exists(), "Word 문서가 생성되지 않았습니다"
+            assert output_path.suffix == ".docx", "확장자가 .docx가 아닙니다"
+            assert output_path.stat().st_size > 0, "생성된 Word 문서가 비어있습니다"
+
+            # 4) 문서 열어 내용 확인
+            doc = Document(str(output_path))
+            texts = "\n".join(_collect_all_texts(doc))
+
+            # 핵심 값들이 문서 어딘가에 존재해야 함 (라벨 기반 매핑 결과)
+            assert title in texts, "제목이 문서에 존재하지 않습니다"
+            assert change_id in texts, "변경관리번호가 문서에 존재하지 않습니다"
+
+            # 목적/개선내용(구조화 텍스트) 일부 키워드 검사
+            assert "1. 목적" in texts, "구조화된 목적 섹션이 없습니다"
+            assert "2. 주요내용" in texts, "구조화된 주요내용 섹션이 없습니다"
+
+            # 요청자/요청부서 또는 고객사 중 일부 값 존재 확인(템플릿에 따라 어느 셀에 들어가도 텍스트 포함되어야 함)
+            req_dept = raw.get("요청부서", "")
+            customer = raw.get("고객사", "")
+            assert requester in texts, "요청자가 문서에 존재하지 않습니다"
+            assert (req_dept in texts) or (customer in texts) or (raw.get("신청자", "") in texts), (
+                "요청부서/고객사/신청자 중 어느 것도 문서에 존재하지 않습니다"
+            )
+
+            # 작업/배포 일시(파서 파생 규칙)
+            work_dt = raw.get("작업일시", "")
+            deploy_dt = raw.get("배포일시", "")
+            if work_dt:
+                assert work_dt in texts, "작업일시가 문서에 존재하지 않습니다"
+            if deploy_dt:
+                assert deploy_dt in texts, "배포일시가 문서에 존재하지 않습니다"
+
+

--- a/autodoc_service/app/tests/test_logging_system.py
+++ b/autodoc_service/app/tests/test_logging_system.py
@@ -1,0 +1,220 @@
+"""
+AutoDoc Service 로깅 시스템 테스트
+
+로깅 설정, 로그 파일 생성, 로그 메시지 형식 등을 검증합니다.
+"""
+import logging
+import os
+import tempfile
+from pathlib import Path
+from datetime import datetime
+import pytest
+
+from ..logging_config import setup_autodoc_logging, get_logger, AutoDocRotatingFileHandler
+
+
+class TestLoggingConfiguration:
+    """로깅 설정 테스트"""
+    
+    def test_setup_autodoc_logging_creates_log_directory(self):
+        """로깅 설정 시 로그 디렉토리가 생성되는지 확인"""
+        # Given
+        setup_autodoc_logging()
+        
+        # When
+        log_dir = Path(__file__).resolve().parents[2] / "logs"
+        
+        # Then
+        assert log_dir.exists(), "로그 디렉토리가 생성되어야 함"
+        assert log_dir.is_dir(), "로그 디렉토리는 폴더여야 함"
+    
+    def test_get_logger_returns_logger_instance(self):
+        """get_logger 함수가 로거 인스턴스를 반환하는지 확인"""
+        # When
+        logger = get_logger("test_module")
+        
+        # Then
+        assert isinstance(logger, logging.Logger), "Logger 인스턴스여야 함"
+        assert logger.name == "test_module", "로거 이름이 일치해야 함"
+    
+    def test_autodoc_rotating_file_handler_filename_format(self):
+        """AutoDocRotatingFileHandler가 올바른 파일명 형식을 사용하는지 확인"""
+        # Given
+        with tempfile.TemporaryDirectory() as temp_dir:
+            handler = AutoDocRotatingFileHandler()
+            
+            # When
+            current_date = datetime.now().strftime('%Y%m%d')
+            expected_filename = f"{current_date}_autodoc.log"
+            
+            # Then
+            assert expected_filename in str(handler.baseFilename), "파일명 형식이 YYYYMMDD_autodoc.log여야 함"
+
+
+class TestLoggingOutput:
+    """로그 출력 테스트"""
+    
+    def test_log_message_format(self):
+        """로그 메시지 형식이 올바른지 확인"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("test_logging")
+        
+        # When
+        test_message = "테스트 로그 메시지"
+        logger.info(test_message)
+        
+        # Then
+        # 로그 파일 확인
+        log_dir = Path(__file__).resolve().parents[2] / "logs"
+        current_date = datetime.now().strftime('%Y%m%d')
+        log_file = log_dir / f"{current_date}_autodoc.log"
+        
+        if log_file.exists():
+            log_content = log_file.read_text(encoding='utf-8')
+            assert test_message in log_content, "로그 메시지가 파일에 기록되어야 함"
+            assert "INFO" in log_content, "로그 레벨이 포함되어야 함"
+            assert "test_logging" in log_content, "로거 이름이 포함되어야 함"
+    
+    def test_logging_different_levels(self):
+        """다양한 로그 레벨이 정상적으로 기록되는지 확인"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("test_levels")
+        
+        # When
+        logger.info("정보 메시지")
+        logger.warning("경고 메시지")
+        logger.error("오류 메시지")
+        
+        # Then
+        log_dir = Path(__file__).resolve().parents[2] / "logs"
+        current_date = datetime.now().strftime('%Y%m%d')
+        log_file = log_dir / f"{current_date}_autodoc.log"
+        
+        if log_file.exists():
+            log_content = log_file.read_text(encoding='utf-8')
+            assert "정보 메시지" in log_content, "INFO 메시지가 기록되어야 함"
+            assert "경고 메시지" in log_content, "WARNING 메시지가 기록되어야 함"
+            assert "오류 메시지" in log_content, "ERROR 메시지가 기록되어야 함"
+
+
+class TestLoggingIntegration:
+    """로깅 시스템 통합 테스트"""
+    
+    def test_multiple_modules_logging(self):
+        """여러 모듈에서 동시에 로깅할 때 정상적으로 동작하는지 확인"""
+        # Given
+        setup_autodoc_logging()
+        logger1 = get_logger("module1")
+        logger2 = get_logger("module2")
+        
+        # When
+        logger1.info("모듈1에서 로그")
+        logger2.info("모듈2에서 로그")
+        
+        # Then
+        log_dir = Path(__file__).resolve().parents[2] / "logs"
+        current_date = datetime.now().strftime('%Y%m%d')
+        log_file = log_dir / f"{current_date}_autodoc.log"
+        
+        if log_file.exists():
+            log_content = log_file.read_text(encoding='utf-8')
+            assert "module1" in log_content, "모듈1 로그가 기록되어야 함"
+            assert "module2" in log_content, "모듈2 로그가 기록되어야 함"
+            assert "모듈1에서 로그" in log_content, "모듈1 메시지가 기록되어야 함"
+            assert "모듈2에서 로그" in log_content, "모듈2 메시지가 기록되어야 함"
+    
+    def test_exception_logging_with_traceback(self):
+        """예외 로깅 시 스택 트레이스가 포함되는지 확인"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("test_exception")
+        
+        # When
+        try:
+            raise ValueError("테스트 예외")
+        except ValueError:
+            logger.exception("예외 발생")
+        
+        # Then
+        log_dir = Path(__file__).resolve().parents[2] / "logs"
+        current_date = datetime.now().strftime('%Y%m%d')
+        log_file = log_dir / f"{current_date}_autodoc.log"
+        
+        if log_file.exists():
+            log_content = log_file.read_text(encoding='utf-8')
+            assert "예외 발생" in log_content, "예외 메시지가 기록되어야 함"
+            assert "ValueError" in log_content, "예외 타입이 기록되어야 함"
+            assert "테스트 예외" in log_content, "예외 내용이 기록되어야 함"
+            assert "Traceback" in log_content, "스택 트레이스가 기록되어야 함"
+
+
+class TestLoggingPerformance:
+    """로깅 성능 테스트"""
+    
+    def test_logging_performance(self):
+        """로깅 성능이 적절한 수준인지 확인"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("performance_test")
+        
+        # When
+        import time
+        start_time = time.time()
+        
+        for i in range(100):
+            logger.info(f"성능 테스트 메시지 {i}")
+        
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        
+        # Then
+        assert elapsed_time < 1.0, f"100개 로그 메시지 처리 시간이 1초를 초과함: {elapsed_time:.3f}s"
+    
+    def test_log_file_rotation_backup_count(self):
+        """로그 파일 백업 개수가 올바르게 설정되는지 확인"""
+        # Given
+        handler = AutoDocRotatingFileHandler(backupCount=7)
+        
+        # Then
+        assert handler.backupCount == 7, "백업 개수가 7일로 설정되어야 함"
+
+
+class TestLoggingErrorHandling:
+    """로깅 오류 처리 테스트"""
+    
+    def test_logging_with_none_values(self):
+        """None 값이 포함된 로그 메시지 처리"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("test_none_handling")
+        
+        # When & Then (예외가 발생하지 않아야 함)
+        logger.info(f"값: {None}")
+        logger.info("파일명: %s, 크기: %s", None, None)
+    
+    def test_logging_with_unicode_content(self):
+        """유니코드 콘텐츠가 포함된 로그 메시지 처리"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("test_unicode")
+        
+        # When & Then (예외가 발생하지 않아야 함)
+        logger.info("한글 로그 메시지: 안녕하세요")
+        logger.info("특수문자: ★☆♡♥※")
+        logger.info("이모지: 📄🔍⚡")
+    
+    def test_logging_with_large_messages(self):
+        """큰 로그 메시지 처리"""
+        # Given
+        setup_autodoc_logging()
+        logger = get_logger("test_large_message")
+        
+        # When & Then (예외가 발생하지 않아야 함)
+        large_message = "A" * 10000  # 10KB 메시지
+        logger.info(f"큰 메시지 테스트: {large_message}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- 테스트-로직 불일치 수정 및 현행화\n  - Excel 목록/시나리오 빌더 테스트 안정화 (좌표 탐색 보강, 템플릿 누락 케이스 개선)\n  - API 통합 테스트: 구현 기준 상태코드/응답 포맷 허용범위 조정\n  - 파서 테스트: 시스템 파생 규칙과 멀티라인 비교 정규화\n- Word 라벨 기반 빌더 테스트 추가 (	est_builder_word_label.py)\n- Python 3.12 venv에서 전체 테스트 통과 (73 passed)\n- .gitignore 업데이트: .venv* 무시\n\n검토 포인트\n- 템플릿 누락 처리 로직: 환경변수 AUTODOC_TPL_DIR 기반 테스트\n- Word 라벨 매핑 결과 핵심 값 포함 여부